### PR TITLE
Template of command action complete

### DIFF
--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const applicationVersion string = "v0.5.6"
+const applicationVersion string = "v0.5.7"
 
 var (
 	Token string
@@ -87,7 +87,7 @@ func main() {
 	// Create a new Discord session using the provided bot token.
 	dg, err := discordgo.New("Bot " + Token)
 	if err != nil {
-		fmt.Println("error creating Discord session,", err)
+		log.Println("error creating Discord session,", err)
 		return
 	}
 
@@ -95,7 +95,7 @@ func main() {
 
 	err = dg.Open()
 	if err != nil {
-		fmt.Println("error opening connection,", err)
+		log.Println("error opening connection,", err)
 		return
 	}
 
@@ -157,38 +157,27 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	// log commands passed to bot
-	log.Printf("User:%s ID:%s Command: \"%s\"\n", m.Author.Username, m.Author.ID, m.Content)
+	log.Printf("User:%s ID:%s Command:\"%s\"\n", m.Author.Username, m.Author.ID, m.Content)
 
 	// strip out the command key
 	cleancommand := strings.Replace(strings.ToLower(m.Content), viper.GetString("commandkey")+" ", "", 1)
 
-	// mycommand = command
-	// iscommandvalid = is command valid
+	// mycommand = the valid command found
+	// iscommandvalid = is command valid?
 	// myoptions = map of all options, ready for templating
 	mycommand, iscommandvalid, myoptions := findCommand(cleancommand)
 
-	fmt.Printf("findcommandreturn: command=%s, isValid?=%b, options=%v\n", mycommand, iscommandvalid, myoptions)
-
 	if !iscommandvalid {
-		fmt.Println("Command:\"%s\" is not valid, ignoring\n", mycommand)
+		log.Printf("User:%s ID:%s Command:\"%s\" Status:\"Command is invalid\"\n", m.Author.Username, m.Author.ID, m.Content)
 		return
 	}
 
-	fmt.Printf("Number of options=%d\n", len(myoptions))
-
-	if _, ok := viper.GetStringMap("commands")[mycommand]; ok {
-		fmt.Printf("command=%s        action=%s\n", mycommand, viper.GetStringMap("commands")[mycommand])
-	}
-
 	aftertemplate := viper.GetStringMap("commands")[mycommand]
-	fmt.Printf("before template replacement: \"%s\"\n", aftertemplate)
+
+	// do all the templating, replace {0} etc in the command with the options the user has given
 	for key, value := range myoptions {
-
 		aftertemplate = strings.Replace(aftertemplate.(string), key, value, -1)
-
 	}
-
-	fmt.Printf(" After template replacement: \"%s\"\n", aftertemplate)
 
 	// find role for the primary command
 	commandrole := getCommandRole(mycommand)
@@ -209,13 +198,11 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// check if command is valid and do appropriate text response
 	if _, ok := viper.GetStringMap("commands")[mycommand]; ok {
 
-		//commandmessageparts := strings.Split(viper.GetStringMap("commands")[mycommand].(string), "|")
 		commandmessageparts := strings.Split(aftertemplate.(string), "|")
 
 		issecret := false
 		isapicall := false
 		isfile := false
-		//istemplate := false
 
 		var messagetosend string
 
@@ -230,9 +217,6 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			if value == "file" {
 				isfile = true
 			}
-			//if value == "template" {
-			//	istemplate = true
-			//}
 		}
 
 		// if api and file then return and throw an error, this is not a valid option configuration
@@ -241,10 +225,9 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			return
 		}
 
-		// strip "api|", "file|", "template|"  and "secret|" from the command
+		// strip "api|", "file|" and "secret|" from the commands action
 		messagetosend = strings.Replace(aftertemplate.(string), "api|", "", -1)
 		messagetosend = strings.Replace(messagetosend, "file|", "", -1)
-		//messagetosend = strings.Replace(messagetosend, "template|", "", -1)
 		messagetosend = strings.Replace(messagetosend, "secret|", "", -1)
 
 		// if an api call do it and get response which will become the message sent to the user
@@ -272,53 +255,6 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		return
 	}
-
-	/*
-		// handle camera related commands
-		if cleancommandparts[1] == "camera" {
-
-			// list cameras
-			if cleancommandparts[2] == "list" {
-
-				cameralisturl := viper.GetString("cameraserver") + "/cameras?json=y"
-
-				cameralist := downloadApi(cameralisturl)
-
-				fmt.Printf("cameralist=%s\n", cameralist)
-
-				s.ChannelMessageSend(m.ChannelID, cameralist)
-
-				return
-			}
-
-			// take snapshot
-			if cleancommandparts[2] == "snapshot" {
-
-				// check that camera given in message/command is valid
-				if foundCamera(cleancommandparts[3]) {
-
-					// take a snapshot
-					snapshotresult := takeSnapshot(cleancommandparts[3])
-
-					// check that return message is valid
-					if strings.HasPrefix(snapshotresult, "files/") {
-						// display link to image
-						s.ChannelMessageSend(m.ChannelID, viper.GetString("cameraurl")+"/"+snapshotresult)
-						log.Printf("User:%s ID:%s Snapshot: \"%s\"\n", m.Author.Username, m.Author.ID, viper.GetString("cameraurl")+"/"+snapshotresult)
-					} else {
-						// display error message from motioneye-snapshotter
-						s.ChannelMessageSend(m.ChannelID, snapshotresult)
-					}
-
-					// camera is not valid
-				} else {
-					s.ChannelMessageSend(m.ChannelID, "Unknown camera")
-				}
-
-			}
-
-		}
-	*/
 }
 
 // make a query to a url
@@ -391,7 +327,6 @@ func getCommandRole(command string) string {
 
 // check if a user has a particular role, if they have a role return true
 func checkUserPerms(role string, user *discordgo.Member, userid string) bool {
-
 	roledetails := strings.Split(strings.ToLower(role), ":")
 
 	if roledetails[0] == "no role set" {
@@ -533,51 +468,35 @@ func findCommand(thecommand string) (string, bool, map[string]string) {
 
 	var lastvalidcommandfound string = ""
 
-	//var command_num int = 0
-	//var optional_num int = 0
-
 	var option_num int = 0
-	//var options map[string]string
 
 	options := make(map[string]string)
 
 	for i := 0; i < num_allparts; i++ {
-		fmt.Printf("%d =================\n", i)
 		if i == 0 {
 			checkthiscommand = allparts[0]
 		} else {
 			checkthiscommand = checkthiscommand + " " + allparts[i]
 		}
 
-		fmt.Println("findCommand: checking " + checkthiscommand)
 		if _, ok := viper.GetStringMap("commands")[checkthiscommand]; ok {
-			fmt.Println("FOUND COMMAND")
 			lastvalidcommandfound = checkthiscommand
 			isValidCommand = true
 
 			// assume all remaining unparse tokens are optional.  each loop will update the list until no further valid commands are found
-
 			option_num = 0
 			new_options := make(map[string]string)
 			for oi := i + 1; oi < num_allparts; oi++ {
-				fmt.Printf("oi=%d  allparts[%d]=%s\n", oi, oi, allparts[oi])
-				fmt.Println("setting new_options")
 				new_options["{"+strconv.Itoa(option_num)+"}"] = allparts[oi]
 				option_num++
 			}
 
-			fmt.Println("before options = new_options")
 			options = new_options
-			fmt.Println("after options = new_options")
 
 		} else {
-			fmt.Println("NOT FOUND COMMAND")
+			// command not matched, continue iterating through commands looking for the longest matching combination
 		}
 
-	}
-
-	for key, value := range options { // Order not specified
-		fmt.Printf("options: key=%s value=%s\n", key, value)
 	}
 
 	return lastvalidcommandfound, isValidCommand, options


### PR DESCRIPTION
Adds the ability to template command actions.

A command can now be set which will allow extra parameters/options to be defined by the user.  These are then templated in to the action with {0} being the first param, {1} the second and so on.

Example:
```
commandkey: "!mybot"
commands:
  "my name is": "secret|Your first name is {0} and surname is {1}"
commandperms:
  "my name is": all
```

The user can then send a message `!mybot my name is boaty mcboatface`

Which will then send the following response as a secret private message: `Your first name is boaty and surname is mcboatface`