### PR TITLE
Config rework mainly roles and some bug fixes

### DIFF
--- a/.github/workflows/docker-public-ghcr-io.yml
+++ b/.github/workflows/docker-public-ghcr-io.yml
@@ -1,0 +1,103 @@
+name: Build and publish a Docker image to ghcr.io
+on:
+
+  # publish on releases, e.g. v2.1.13 (image tagged as "2.1.13" - "v" prefix is removed)
+  release:
+    types: [ published ]
+
+  # publish on pushes to the main branch (image tagged as "latest")
+  push:
+    branches:
+      - master
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  
+jobs:
+  docker_publish:
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        go-version: [ '1.22' ]
+        
+    steps:
+      - uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Show Go version
+        run: |
+          go version
+
+      - name: Extract application version
+        shell: bash
+        run: |
+          APP_VERSION=$(cat ./simple-discord-bot.go|grep ^const\ applic|cut -f5 -d\ |sed 's/\"//g')
+          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
+
+      - name: Show application version
+        shell: bash
+        run: echo $APP_VERSION
+        env:
+          APP_VERSION: ${{ env.APP_VERSION }}
+          
+      - name: Install dependencies
+        run: |
+          go get .
+
+      - name: Build
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w"
+        
+      - name: Install UPX
+        uses: crazy-max/ghaction-upx@v3
+        with:
+          install-only: true
+
+      - name: Run UPX
+        run: upx ./simple-discord-bot
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          #tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/${{ github.repository }}:${{ env.APP_VERSION }} , ghcr.io/${{ github.repository }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish-docker-hub.yml
+++ b/.github/workflows/docker-publish-docker-hub.yml
@@ -1,0 +1,102 @@
+name: Build and publish a Docker image to Docker Hub
+on:
+
+  # publish on releases, e.g. v2.1.13 (image tagged as "2.1.13" - "v" prefix is removed)
+  release:
+    types: [ published ]
+
+  # publish on pushes to the main branch (image tagged as "latest")
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  
+jobs:
+  docker_publish:
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        go-version: [ '1.22' ]
+        
+    steps:
+      - uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Show Go version
+        run: |
+          go version
+
+      - name: Extract application version
+        shell: bash
+        run: |
+          APP_VERSION=$(cat ./simple-discord-bot.go|grep ^const\ applic|cut -f5 -d\ |sed 's/\"//g')
+          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
+
+      - name: Show application version
+        shell: bash
+        run: echo $APP_VERSION
+        env:
+          APP_VERSION: ${{ env.APP_VERSION }}
+          
+      - name: Install dependencies
+        run: |
+          go get .
+
+      - name: Build
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w"
+        
+      - name: Install UPX
+        uses: crazy-max/ghaction-upx@v3
+        with:
+          install-only: true
+
+      - name: Run UPX
+        run: upx ./simple-discord-bot
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          #tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ github.repository }}:${{ env.APP_VERSION }} , ${{ github.repository }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.yaml
 help.txt
+__debug_bin*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.yaml
+help.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.yaml
 help.txt
 __debug_bin*
+simple-discord-bot

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "golang.go"
+    ]
+}

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 MYAPP="simple-discord-bot"
-GOOS=linux GOARCH=amd64 go build -ldflags "-s -w"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -v ./...
 upx ./${MYAPP}
 
 VERSION=$(cat ${MYAPP}.go|grep ^const\ applic|cut -f5 -d\ |sed 's/\"//g')

--- a/examples/config.example
+++ b/examples/config.example
@@ -60,5 +60,5 @@ reactions:
       type: "role"
       channel_id: 1212121212
       message_id: 1234567890
-      emoji: "😁"
+      emoji: "name:3434343434"
       role_id: 2222222222

--- a/examples/config.example
+++ b/examples/config.example
@@ -1,25 +1,100 @@
 discordtoken: aaaaaBBBBBBBcccccDDDDDD
+defaultserverid: 123123123123123123
 canaryenable: true
 canaryinterval: 10
 canaryurl: "http://172.28.0.10:54035/checkin/eeh-bot"
 shellenable: true
 shell: sh
 commandkey: "!eeh"
+
 commands:
-  wiki: "https://eehack.space"
-  www: "https://eehack.space"
-  web: "https://eehack.space"
-  status: "https://status.eehack.space/"
-  gatecode: "secret|Gatecode: `1234`"
-  botwatcher: "https://botwatcher.eehack.space/status"
-  help: "secret|file|/path/to/help.txt"
-  "camera list": "api|http://172.28.0.10:54036/cameras"
-  "camera snapshot": "secret|api|http://172.28.0.10:54036/snap?camera={0}"
-  "server ip": "api|https://api.ipify.org"
-  "my name is": "secret|Your first name is {0} and surname is {1}"
-  "ls -la": "shell|ls -la"
-  "sendmessage": "secret|function|sendMessage"
-  "editmessage": "secret|function|editMessage"
+  "wiki":
+    help: "EEH Wiki"
+    message: "https://eehack.space"
+    roles:
+      - all
+  "web":
+    help: "Website"
+    message: "https://eehack.space"
+    roles:
+      - all
+  "www":
+    help: "Website"
+    message: "https://eehack.space"
+    roles:
+      - all
+  "gatecode":
+    help: "Display car park gatecode"
+    message: "Gatecode `0451`"
+    secret: true
+    roles:
+      - discord:hackers
+      - discord:matt
+  "status":
+    help: "Status"
+    message: "https://status.eehack.space/"
+    roles:
+      - all
+  "botwatcher":
+    help: "Botwatcher"
+    message: "https://botwatcher.eehack.space/status"
+    roles:
+      - discord:matt
+      - discord:vicky
+  "help":
+    help: "Shows this!"
+    function: "showHelp"
+    secret: true
+    roles:
+      - all
+  "instructions":
+    help: "Shows some instructions"
+    file: "/path/to/instructions.txt"
+    secret: true
+    roles:
+      - all
+  "camera snapshot":
+    help: "Take a snapshot of the camera"
+    api: "http://172.28.0.10:54036/snap?camera={0}"
+    secret: true
+    roles:
+      - admin
+  "camera list":
+    help: "Display list of cameras"
+    api: "http://172.28.0.10:54036/cameras"
+    roles:
+      - admin
+  "server ip":
+    help: "Shows external IP"
+    api: "https://api.ipify.org"
+    secret: true
+    roles:
+      - admin
+  "my name is":
+    help: "Shows your name if you type !cmd my name is Joe Bloggs"
+    message: "Your first name is {0} and surname is {1}"
+    secret: true
+    roles:
+      - admin
+  "ls -la":
+    help: "Shows file listing"
+    shell: "ls -la"
+    secret: true
+    roles:
+      - admin
+  "sendmessage":
+    help: "Sends message as the bot to a channel - sendmessage <channel_id> <message>"
+    function: "sendMessage"
+    secret: true
+    roles:
+      - admin
+  "editmessage":
+    help: "Edits a message the bot has sent - editmessage <channel_id> <message_id> <message>"
+    function: "editMessage"
+    secret: true
+    roles:
+      - admin
+
 commandroles:
   admin:
     - 111111111111111111
@@ -29,26 +104,11 @@ commandroles:
   members:
     - 111111111111111111
       # user1
-commandperms:
-  wiki: all
-  www: "discord:role_1"
-  web: "discord:role_2"
-  status: all
-  gatecode: members
-  botwatcher: all
-  camera: admin
-  gatecode: members
-  help: all
-  "camera list": all
-  "camera snapshot": "discord:role_2"
-  "server ip": admin
-  "my name is": all
-  "ls -la": admin
-  "sendmessage": admin
-  "editmessage": admin
+
 discordroles:
   role_1: 123456789123456789
   role_2: 987654321987654321
+
 reactions:
     name1:
       type: "role"

--- a/examples/config.example
+++ b/examples/config.example
@@ -49,3 +49,14 @@ commandperms:
 discordroles:
   role_1: 123456789123456789
   role_2: 987654321987654321
+reactions:
+    name1:
+      type: "role"
+      message_id: 1234567890
+      emoji: "😂"
+      role_id: 1111111111
+    name2:
+      type: "role"
+      message_id: 1234567890
+      emoji: "😁"
+      role_id: 2222222222

--- a/examples/config.example
+++ b/examples/config.example
@@ -18,6 +18,8 @@ commands:
   "server ip": "api|https://api.ipify.org"
   "my name is": "secret|Your first name is {0} and surname is {1}"
   "ls -la": "shell|ls -la"
+  "sendmessage": "secret|function|sendMessage"
+  "editmessage": "secret|function|editMessage"
 commandroles:
   admin:
     - 111111111111111111
@@ -42,6 +44,8 @@ commandperms:
   "server ip": admin
   "my name is": all
   "ls -la": admin
+  "sendmessage": admin
+  "editmessage": admin
 discordroles:
   role_1: 123456789123456789
   role_2: 987654321987654321

--- a/examples/config.example
+++ b/examples/config.example
@@ -52,11 +52,13 @@ discordroles:
 reactions:
     name1:
       type: "role"
+      channel_id: 1212121212
       message_id: 1234567890
       emoji: "😂"
       role_id: 1111111111
     name2:
       type: "role"
+      channel_id: 1212121212
       message_id: 1234567890
       emoji: "😁"
       role_id: 2222222222

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -318,7 +318,12 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		if isfunction {
 			lengthOfMessageWithoutCommand := len(viper.GetString("commandkey")) + 1 + len(mycommand) + 1
-			message := m.Content[lengthOfMessageWithoutCommand:]
+			var message string
+			if lengthOfMessageWithoutCommand > len(m.Content) {
+				message = ""
+			} else {
+				message = m.Content[lengthOfMessageWithoutCommand:]
+			}
 
 			functionName := messagetosend
 			// Map function names to actual functions

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -174,6 +174,8 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if guild != nil {
 		author, _ = s.GuildMember(guild.ID, m.Author.ID)
+	} else {
+		author, _ = s.GuildMember(viper.GetString("defaultserverid"), m.Author.ID)
 	}
 
 	// ignore commands we don't care about
@@ -189,33 +191,34 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// mycommand = the valid command found
 	// iscommandvalid = is command valid?
-	// myoptions = map of all options, ready for templating
-	mycommand, iscommandvalid, myoptions := findCommand(cleancommand)
+	// commandoptions = map of all options, ready for templating
+	mycommand, iscommandvalid, commandoptions := findCommand(cleancommand)
 
 	if !iscommandvalid {
 		log.Printf("User:%s ID:%s Command:\"%s\" Status:\"Command is invalid\"\n", m.Author.Username, m.Author.ID, m.Content)
 		return
 	}
 
-	aftertemplate := viper.GetStringMap("commands")[mycommand]
-
-	// do all the templating, replace {0} etc in the command with the options the user has given
-	for key, value := range myoptions {
-		aftertemplate = strings.Replace(aftertemplate.(string), key, value, -1)
-	}
-
 	// find role for the primary command
-	commandrole := getCommandRole(mycommand)
+	commandRoles := viper.GetStringSlice("commands." + mycommand + ".roles")
 
 	// check if a role has been assigned to the command, and ignore if none has been set or role is invalid
-	if !isRoleValid(commandrole) {
-		// role doesn't exist
-		log.Printf("Error: commandrole doesnt exist for %s", mycommand)
-		return
+	for _, role := range commandRoles {
+		if !isRoleValid(role) {
+			// role doesn't exist
+			log.Printf("Error: role (%s) not valid do not exist for command %s", role, mycommand)
+			return
+		}
 	}
 
-	// check if user has permissions to execute a command
-	if !checkUserPerms(commandrole, author, m.Author.ID) {
+	// check if user has permission to execute a command
+	var canRun bool = false
+	for _, role := range commandRoles {
+		if checkUserPerms(role, author, m.Author.ID) {
+			canRun = true
+		}
+	}
+	if !canRun {
 		log.Printf("Error: User:%s ID:%s Does not have permission to run Command: \"%s\"\n", m.Author.Username, m.Author.ID, m.Content)
 		return
 	}
@@ -223,78 +226,50 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// check if command is valid and do appropriate text response
 	if _, ok := viper.GetStringMap("commands")[mycommand]; ok {
 
-		commandmessageparts := strings.Split(aftertemplate.(string), "|")
-
-		issecret := false
-		isapicall := false
-		isfile := false
-		isshell := false
-		isfunction := false
-
-		var messagetosend string
-
-		// discern whether command is an apicall or secret
-		for _, value := range commandmessageparts {
-			if value == "secret" {
-				issecret = true
-			}
-			if value == "api" {
-				isapicall = true
-			}
-			if value == "file" {
-				isfile = true
-			}
-			if value == "shell" {
-				isshell = true
-			}
-			if value == "function" {
-				isfunction = true
-			}
-		}
+		ismessage := viper.IsSet("commands." + mycommand + ".message")
+		isapicall := viper.IsSet("commands." + mycommand + ".api")
+		isfile := viper.IsSet("commands." + mycommand + ".file")
+		isshell := viper.IsSet("commands." + mycommand + ".shell")
+		isfunction := viper.IsSet("commands." + mycommand + ".function")
+		issecret := viper.GetBool("commands." + mycommand + ".secret")
 
 		// if api and file then return and throw an error, this is not a valid option configuration
 		if isapicall && isfile {
-			log.Printf("Error: Cannot have command api| with file| on command %s\n", mycommand)
+			log.Printf("Error: Cannot have command api with file on command %s\n", mycommand)
 			return
 		}
 
 		// if shell and (file or api) then return and throw an error, this is not a valid option configuration
 		if isshell && (isfile || isapicall) {
-			log.Printf("Error: Cannot have command shell| with file| or api| on command %s\n", mycommand)
+			log.Printf("Error: Cannot have command shell with file or api on command %s\n", mycommand)
 			return
 		}
 
 		// if function and (file or api or shell) then return and throw an error, this is not a valid option configuration
 		if isfunction && (isshell || isfile || isapicall) {
-			log.Printf("Error: Cannot have command function| with shell| or file| or api| on command %s\n", mycommand)
+			log.Printf("Error: Cannot have command function with shell or file or api on command %s\n", mycommand)
 			return
 		}
 
-		// strip "shell|", "api|", "file|", "function|" and "secret|" from the commands action
-		messagetosend = strings.Replace(aftertemplate.(string), "api|", "", -1)
-		messagetosend = strings.Replace(messagetosend, "file|", "", -1)
-		messagetosend = strings.Replace(messagetosend, "secret|", "", -1)
-		messagetosend = strings.Replace(messagetosend, "shell|", "", -1)
-		messagetosend = strings.Replace(messagetosend, "function|", "", -1)
+		var messagetosend string
 
-		// if an api call do it and get response which will become the message sent to the user
-		if isapicall {
-			messagetosend = downloadApi(messagetosend)
-		}
+		if ismessage {
+			messagetosend = prepareTemplate(viper.GetString("commands."+mycommand+".message"), commandoptions)
+		} else if isapicall {
+			// if an api call do it and get response which will become the message sent to the user
+			messagetosend = downloadApi(prepareTemplate(viper.GetString("commands."+mycommand+".api"), commandoptions))
 
-		// if we need to load a files contents into message to send
-		if isfile {
-			tempcontents, err := loadFile(messagetosend)
+		} else if isfile {
+			// if we need to load a files contents into message to send
+			tempcontents, err := loadFile(prepareTemplate(viper.GetString("commands."+mycommand+".file"), commandoptions))
 			if err != nil {
 				log.Printf("Error loading file: %s with: %v\n", messagetosend, err)
 				return
 			}
 
 			messagetosend = tempcontents
-		}
-
-		if isshell && viper.GetBool("shellenable") {
-			err, stdout, stderr := shellOut(messagetosend)
+		} else if isshell && viper.GetBool("shellenable") {
+			err, stdout, stderr := shellOut(prepareTemplate(viper.GetString("commands."+mycommand+".shell"), commandoptions))
 			if err != nil {
 				log.Printf("Error: Error executing command:\"%s\" err:%v\n", messagetosend, err)
 			}
@@ -312,15 +287,11 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			if len(messagetosend) == 8 {
 				return
 			}
-		}
-
-		// do nothing and return when command is a shell and shellenable = false
-		if isshell && !viper.GetBool("shellenable") {
+		} else if isshell && !viper.GetBool("shellenable") {
+			// do nothing and return when command is a shell and shellenable = false
 			log.Println("Error: Cannot run shell command when shellenable = false")
 			return
-		}
-
-		if isfunction {
+		} else if isfunction {
 			lengthOfMessageWithoutCommand := len(viper.GetString("commandkey")) + 1 + len(mycommand) + 1
 			var message string
 			if lengthOfMessageWithoutCommand > len(m.Content) {
@@ -329,12 +300,13 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				message = m.Content[lengthOfMessageWithoutCommand:]
 			}
 
-			functionName := messagetosend
+			functionName := prepareTemplate(viper.GetString("commands."+mycommand+".function"), commandoptions)
 			// Map function names to actual functions
 			functions := map[string]func(*discordgo.Session, *discordgo.MessageCreate, string){
 				"sendMessage": sendMessage,
 				"editMessage": editMessage,
 				"listEmoji":   listEmoji,
+				"showHelp":    showHelp,
 			}
 
 			// Call the function based on the name
@@ -363,6 +335,15 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		return
 	}
+}
+
+func prepareTemplate(message string, commandoptions map[string]string) string {
+	// do all the templating, replace {0} etc in the command with the options the user has given
+	for key, value := range commandoptions {
+		message = strings.Replace(message, key, value, -1)
+	}
+
+	return message
 }
 
 // discord addReaction handler
@@ -521,6 +502,67 @@ func listEmoji(s *discordgo.Session, m *discordgo.MessageCreate, content string)
 	}
 }
 
+// custom command function to list all Emoji
+func showHelp(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
+
+	user, _ := s.GuildMember(viper.GetString("defaultserverid"), m.Author.ID)
+
+	var helpMessage string
+
+	commandkey := viper.GetString("commandkey")
+
+	allCommands := viper.GetStringMap("commands")
+
+	// Loop through the commands map
+	for command, info := range allCommands {
+
+		// check if user has permission to execute a command
+		var canRun bool = false
+
+		// Access the "roles" for each command
+		roles, ok := info.(map[string]interface{})["roles"]
+		if !ok {
+			fmt.Printf("Help information not found for command %s\n", command)
+			continue
+		}
+
+		for _, role := range roles.([]interface{}) {
+			fmt.Println(role.(string))
+			if checkUserPerms(role.(string), user, m.Author.ID) {
+				canRun = true
+			}
+		}
+
+		if canRun {
+			// Access the "help" field for each command
+			help, ok := info.(map[string]interface{})["help"].(string)
+			if !ok {
+				fmt.Printf("Help information not found for command %s\n", command)
+				continue
+			}
+
+			helpMessage += commandkey + " " + command + strings.Repeat(" ", 30-len(command)) + "- " + help + "\n"
+			fmt.Printf("Command: %s\nHelp: %s\n\n", command, help)
+		}
+
+	}
+
+	// sort commands into alphabetical order
+
+	// Split the string into lines
+	lines := strings.Split(helpMessage, "\n")
+
+	// Sort the lines alphabetically
+	sort.Strings(lines)
+
+	// Join the sorted lines back together
+	helpMessage = strings.Join(lines, "\n")
+
+	helpMessage = "Help Commands:\n--------------\n" + helpMessage
+
+	privateMessageCreate(s, m.Author.ID, helpMessage, true)
+}
+
 // make a query to a url
 func downloadApi(url string) string {
 	resp, err := http.Get(url)
@@ -577,16 +619,6 @@ func foundCamera(camera string) bool {
 		}
 	}
 	return false
-}
-
-// tells us what role a command requires
-func getCommandRole(command string) string {
-	if viper.IsSet("commandperms") {
-		if _, ok := viper.GetStringMap("commandperms")[command]; ok {
-			return viper.GetStringMap("commandperms")[command].(string)
-		}
-	}
-	return "no role set"
 }
 
 // check if a user has a particular role, if they have a role return true
@@ -670,9 +702,9 @@ func isRoleValid(role string) bool {
 	}
 
 	// check if normal role
-	if viper.IsSet("commandroles") {
+	if viper.IsSet("permissions") {
 		if _, ok := viper.GetStringMap("commandroles")[roledetails[0]]; ok {
-			// found valid role in commandroles
+			// found valid role in permissions
 			return true
 		}
 	}

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -327,14 +327,14 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 			functionName := messagetosend
 			// Map function names to actual functions
-			functions := map[string]func(*discordgo.Session, string){
+			functions := map[string]func(*discordgo.Session, *discordgo.MessageCreate, string){
 				"sendMessage": sendMessage,
 				"editMessage": editMessage,
 			}
 
 			// Call the function based on the name
 			if function, ok := functions[functionName]; ok {
-				function(s, message)
+				function(s, m, message)
 			} else {
 				fmt.Println("Function", functionName, "not found")
 			}
@@ -347,11 +347,13 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			usewrapper = true
 		}
 
-		// send the command response, if marked as secret send via private message
-		if issecret {
-			privateMessageCreate(s, m.Author.ID, messagetosend, usewrapper)
-		} else {
-			channelMessageCreate(s, m, messagetosend, usewrapper)
+		// send the command response, if marked as secret send via private message do not send if command is a custom function
+		if !isfunction {
+			if issecret {
+				privateMessageCreate(s, m.Author.ID, messagetosend, usewrapper)
+			} else {
+				channelMessageCreate(s, m, messagetosend, usewrapper)
+			}
 		}
 
 		return
@@ -405,7 +407,7 @@ func removeReaction(s *discordgo.Session, mr *discordgo.MessageReactionRemove) {
 }
 
 // custom command function for sending messages as the bot
-func sendMessage(s *discordgo.Session, content string) {
+func sendMessage(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
 
 	// split the string by whitespace
 	words := strings.Split(content, " ")
@@ -421,7 +423,7 @@ func sendMessage(s *discordgo.Session, content string) {
 }
 
 // custom command function for editing messages as the bot
-func editMessage(s *discordgo.Session, content string) {
+func editMessage(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
 
 	// split the string by whitespace
 	words := strings.Split(content, " ")

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const applicationVersion string = "v0.7.2"
+const applicationVersion string = "v0.7.3"
 
 var (
 	Token string

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -467,12 +467,14 @@ func checkUserPerms(role string, user *discordgo.Member, userid string) bool {
 	if roledetails[0] == "discord" {
 		// check if users allowed via discord roles
 
-		usersDiscordRoles := user.Roles
+		if user != nil {
+			usersDiscordRoles := user.Roles
 
-		for _, v := range usersDiscordRoles {
-			if v == strconv.Itoa(viper.GetStringMap("discordroles")[roledetails[1]].(int)) {
-				// found users discord role
-				return true
+			for _, v := range usersDiscordRoles {
+				if v == strconv.Itoa(viper.GetStringMap("discordroles")[roledetails[1]].(int)) {
+					// found users discord role
+					return true
+				}
 			}
 		}
 

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -702,7 +702,7 @@ func isRoleValid(role string) bool {
 	}
 
 	// check if normal role
-	if viper.IsSet("permissions") {
+	if viper.IsSet("commandroles") {
 		if _, ok := viper.GetStringMap("commandroles")[roledetails[0]]; ok {
 			// found valid role in permissions
 			return true

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -98,6 +98,10 @@ func main() {
 
 	dg.AddHandler(messageCreate)
 
+	dg.AddHandler(addReaction)
+
+	dg.AddHandler(removeReaction)
+
 	err = dg.Open()
 	if err != nil {
 		log.Println("error opening connection,", err)
@@ -346,6 +350,48 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 
 		return
+	}
+}
+
+// discord addReaction handler
+func addReaction(s *discordgo.Session, mr *discordgo.MessageReactionAdd) {
+	for _, v := range viper.GetStringMap("reactions") {
+		if m, ok := v.(map[string]interface{}); ok {
+			// check message id is being tracked
+			if strconv.Itoa(m["message_id"].(int)) == mr.MessageID {
+				// check emoji is being tracked for this message
+				if m["emoji"] == mr.Emoji.Name {
+					// check which type of reaction this is
+					if m["type"] == "role" {
+						//  add role
+						s.GuildMemberRoleAdd(mr.GuildID, mr.UserID, strconv.Itoa(m["role_id"].(int)))
+					}
+				}
+			}
+		} else {
+			fmt.Println("Data is not a map[string]interface{}")
+		}
+	}
+}
+
+// discord removeReaction handler
+func removeReaction(s *discordgo.Session, mr *discordgo.MessageReactionRemove) {
+	for _, v := range viper.GetStringMap("reactions") {
+		if m, ok := v.(map[string]interface{}); ok {
+			// check message id is being tracked
+			if strconv.Itoa(m["message_id"].(int)) == mr.MessageID {
+				// check emoji is being tracked for this message
+				if m["emoji"] == mr.Emoji.Name {
+					// check which type of reaction this is
+					if m["type"] == "role" {
+						// remove role
+						s.GuildMemberRoleRemove(mr.GuildID, mr.UserID, strconv.Itoa(m["role_id"].(int)))
+					}
+				}
+			}
+		} else {
+			fmt.Println("Data is not a map[string]interface{}")
+		}
 	}
 }
 

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -508,15 +508,15 @@ func listEmoji(s *discordgo.Session, m *discordgo.MessageCreate, content string)
 		}
 
 		if m.GuildID != "" {
-			channelMessageCreate(s, m, message, false)
+			channelMessageCreate(s, m, "**Emoji for "+guildID+"**\n"+message, false)
 		} else {
-			privateMessageCreate(s, m.Author.ID, message, true)
+			privateMessageCreate(s, m.Author.ID, "**Emoji for "+guildID+"**\n```"+message+"```", false)
 		}
 	} else {
 		if m.GuildID != "" {
 			channelMessageCreate(s, m, "Guild/Server ID not found", false)
 		} else {
-			privateMessageCreate(s, m.Author.ID, "Guild/Server ID not found", true)
+			privateMessageCreate(s, m.Author.ID, "Guild/Server ID not found", false)
 		}
 	}
 }

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -395,6 +395,7 @@ func removeReaction(s *discordgo.Session, mr *discordgo.MessageReactionRemove) {
 	}
 }
 
+// custom command function for sending messages as the bot
 func sendMessage(s *discordgo.Session, content string) {
 
 	// split the string by whitespace
@@ -410,6 +411,7 @@ func sendMessage(s *discordgo.Session, content string) {
 	s.ChannelMessageSend(channelID, message)
 }
 
+// custom command function for editing messages as the bot
 func editMessage(s *discordgo.Session, content string) {
 
 	// split the string by whitespace

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const applicationVersion string = "v0.7.2"
+const applicationVersion string = "v0.7.4"
 
 var (
 	Token string

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -359,11 +359,13 @@ func addReaction(s *discordgo.Session, mr *discordgo.MessageReactionAdd) {
 		if m, ok := v.(map[string]interface{}); ok {
 			// check message id is being tracked
 			if strconv.Itoa(m["message_id"].(int)) == mr.MessageID {
+
 				// check emoji is being tracked for this message
-				if m["emoji"] == mr.Emoji.Name {
+				emoji := strings.Split(m["emoji"].(string), ":")
+				if emoji[0] == mr.Emoji.Name {
 					// check which type of reaction this is
 					if m["type"] == "role" {
-						//  add role
+						// add role
 						s.GuildMemberRoleAdd(mr.GuildID, mr.UserID, strconv.Itoa(m["role_id"].(int)))
 					}
 				}
@@ -380,8 +382,10 @@ func removeReaction(s *discordgo.Session, mr *discordgo.MessageReactionRemove) {
 		if m, ok := v.(map[string]interface{}); ok {
 			// check message id is being tracked
 			if strconv.Itoa(m["message_id"].(int)) == mr.MessageID {
+
 				// check emoji is being tracked for this message
-				if m["emoji"] == mr.Emoji.Name {
+				emoji := strings.Split(m["emoji"].(string), ":")
+				if emoji[0] == mr.Emoji.Name {
 					// check which type of reaction this is
 					if m["type"] == "role" {
 						// remove role

--- a/simple-discord-bot.go
+++ b/simple-discord-bot.go
@@ -330,6 +330,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			functions := map[string]func(*discordgo.Session, *discordgo.MessageCreate, string){
 				"sendMessage": sendMessage,
 				"editMessage": editMessage,
+				"listEmoji":   listEmoji,
 			}
 
 			// Call the function based on the name
@@ -439,6 +440,50 @@ func editMessage(s *discordgo.Session, m *discordgo.MessageCreate, content strin
 
 	// edits message in channel
 	s.ChannelMessageEdit(channelID, messageID, message)
+}
+
+// custom command function to list all Emoji
+func listEmoji(s *discordgo.Session, m *discordgo.MessageCreate, content string) {
+
+	words := strings.Split(content, " ")
+
+	// get guild ID from message
+	guildID := strings.Join(words[0:1], " ")
+
+	//	var guildID string = m.GuildID
+
+	if guildID == "" {
+		guildID = m.GuildID
+	}
+
+	if guildID != "" {
+		emojis, err := s.GuildEmojis(guildID)
+		if err != nil {
+			log.Printf("Error: could not get emoji with error:%s", err)
+		}
+
+		var message string
+
+		for _, emoji := range emojis {
+			if m.GuildID != "" {
+				message += "<:" + emoji.Name + ":" + emoji.ID + ">  `" + emoji.ID + "    " + emoji.Name + "`\n"
+			} else {
+				message += emoji.ID + "    " + emoji.Name + "\n"
+			}
+		}
+
+		if m.GuildID != "" {
+			channelMessageCreate(s, m, message, false)
+		} else {
+			privateMessageCreate(s, m.Author.ID, message, true)
+		}
+	} else {
+		if m.GuildID != "" {
+			channelMessageCreate(s, m, "Guild/Server ID not found", false)
+		} else {
+			privateMessageCreate(s, m.Author.ID, "Guild/Server ID not found", true)
+		}
+	}
 }
 
 // make a query to a url


### PR DESCRIPTION
Reworked the config for commands.

The format is now:

```yaml
  "botwatcher":
    help: "Botwatcher"
    message: "https://botwatcher.eehack.space/status"
    roles:
      - discord:members
      - discord:test-users
    secret: true
```

The `message:` can be:
* message:
* shell:
* file:
* api:
* function:
This replaces the piped prefixes on the commands.

Multiple roles can now be specified per command which fixed #11 


With the addition of the `help:` value this means the !cmd help command generates an A-Z list of commands that you have access to based on permissions. Fixes #9 


The config now has a `defaultserverid:` this allows permission checks to be done when messages are sent to the bot via a PM. Fixes #7 and fixes #5 (this was also fixed differently in #12 
